### PR TITLE
update chokidar and clean up formatting to let npm test pass

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "cac": "^2.2.0",
     "chalk": "^1.1.3",
-    "chokidar": "^1.6.0",
+    "chokidar": "^2.0.0",
     "cross-spawn": "^4.0.0",
     "read-pkg": "^2.0.0"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -9,25 +9,29 @@ export default function watch(files, scripts, {
   let init = false
   const watcher = chokidar.watch(files)
 
-  // run for first time
+  // Run for first time
+
   run(scripts)
 
-  // watch changes
+  // Watch changes
   watcher
     .on('ready', () => {
       if (verbose) {
         log.info('nswatch', `watcher for \`${chalk.bold(scripts)}\` is ready`)
       }
+
       init = true
     })
     .on('all', (e, p) => {
-      // unwatch files if they are removed
+      // Unwatch files if they are removed
       if (e === 'unlink') {
         watcher.unwatch(p)
       }
+
       if (init && verbose) {
         log.info('nswatch', `rerun \`${chalk.bold(scripts)}\` due to changes`)
       }
+
       if (init) {
         run(scripts)
       }

--- a/src/run-sequence.js
+++ b/src/run-sequence.js
@@ -9,6 +9,7 @@ export default function runSequence(scripts) {
         if (err) {
           log.error(script, err)
         }
+
         exec()
       })
     }

--- a/src/spawn.js
+++ b/src/spawn.js
@@ -16,6 +16,7 @@ export default function spawn(command, args = [], cb = defaultCb) {
     if (code !== 0) {
       err = `script ${script} exited with wrong status code ${code}`
     }
+
     cb(err)
   })
 }


### PR DESCRIPTION
### Summary
There is a downstream vulnerability flagged by `snyk` which is present in `chokidar < 1.7.0` (see issue https://github.com/fecgov/fec-cms/issues/3226). This PR resolves the vulnerability in the dependency chain resulting from `chokidar@1.6.0`.

This PR does not change the `nswatch@0.2.0` however. If the maintainers prefer, I can also bump the versioning as needed. 

Thank you!
Jason Upchurch